### PR TITLE
cleaning up and a bit of refactoring on thumbmake.js

### DIFF
--- a/aws_lambda/thumbmake.js
+++ b/aws_lambda/thumbmake.js
@@ -1,89 +1,131 @@
 var AWS = require('aws-sdk');
 var S3 = new AWS.S3();
-var fs= require('fs');
+var fs = require('fs');
 var path = require('path');
 const im = require('imagemagick');
 
+//change this to change target bucket
+//TODO: pass this value through AWS lamda console
+const BUCKET = 'labe-storage'; //<-- could take it from event info 
 
- var BUCKET = 'labe-storage';
-// var URL = process.env.URL;
-
-exports.handler = function(event, context, cb) {
-  var key = (event.key?event.key:"nokey");
-  if(key!='nokey'){
-  var match = key.match(/(\d+)\/(.*)/);
-  if(match){
-  var size = parseInt(match[1], 10);
-  var fname= match[2];
-  var originalKey = "uploads" + size + "/" + fname ;
+/**
+ * thumbmake.js
+ * Author: Paolo L.
+ * 
+ * Export an AWS Lambda handler designed to be activated by a S3 bucket event 
+ * to resize new file and upload it back to S3
+ * 
+ * @param {any} event   event raised by S3 conytaining file info 
+ * @param {any} context info about enviroment (not used here)
+ * @param {any} cb      call back used by AWS enviroment
+ * 
+ * TODO: 
+ * refactory on key parsing and to improve promises flow
+ * send a feedback if function fails
+ */
+exports.handler = function (event, context, cb) {
   
-  console.log(width,height,originalKey);
+  var size;         //new size for the image file
+  var fname;        //file name
+  var originalKey;  //path/key of the new uploaded image rising event
   
-    }
-    console.log(width,height,originalKey);
+  var key = (event.key ? event.key : "nokey");
+  //Checking key to understand who is calling the handler
+  //for developing purpose I can call the handler from simple AWS test engine
+  if (key != 'nokey') {
+   
+    //calling from AWS test
+    var match = key.match(/(\d+)\/(.*)/);
+    if (match) {
+        size = parseInt(match[1], 10);
+        fname = match[2];
+        originalKey = "uploads" + size + "/" + fname;
+      }
   }
-  else
-  {
-      //recover resource from bucket event
-    const bucket = event.Records[0].s3.bucket.name;
-    key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
-    console.log("put file",key);
-    match = key.match(/uploads(\d+)\/(.*)/);
-    var size=parseInt(match[1], 10);
-    fname= match[2];
-    console.log("size",size);
+  else {
+    //Calling from 
+    //An put event is coming from the target bucket
+    //becaouse a trigger is configured in asw lambda
 
+    //parsing bucket info
+    const bucket = event.Records[0].s3.bucket.name;
+
+    //extract the new file path 
+    key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
+    console.log("put file", key);
+
+    //extract size from path, just to know the destination size
+    //the file can be placed in uploads360 or uploads120 
+    match = key.match(/uploads(\d+)\/(.*)/);
+
+    //first group is the size
+    var size = parseInt(match[1], 10);
+
+    //second group is the file name
+    fname = match[2];
+    console.log("size", size);
+
+    //params for S3 API
     const params = {
-        Bucket: bucket,
-        Key: key
+      Bucket: bucket,
+      Key: key
     };
 
-    
-    originalKey=key;
+    //I have to copy file in a different folder so save the original path
+    originalKey = key;
   }
 
-  var width=size;
-  var height=size;
+  //the image will fit this square mantaining aspect ratio
+  var width = size;
+  var height = size;
 
-  //var destKey= "images" + size + "/" + fname;
-  var destKey= "images" + size + "/" + fname;
+  //set the destination path based on size
+  var destKey = "images" + size + "/" + fname;
+
+  //I've to save the resized stream in a local tmp folder before uploading it
+  //TODO: Investigate why saving the resized stream directly on S3 create a broken image
   var resizedFile = "/tmp/" + fname;
-    console.log("opening",originalKey);
-   S3.getObject({Bucket: BUCKET, Key: originalKey}).promise()
-    // .then((data) => Sharp(data.Body)
-    //     .resize(width, height)
-    //     .toFormat('png')
-    //     .toBuffer()
-    // )
-    .then((data)=>{
-        console.log("resize ...");
-        im.resize({
-          srcData: data.Body,
-          dstPath: resizedFile,
-          width:   width,
-          height: height,
-        }, function(err, stdout, stderr){
-          if (err) cb(err);
-          console.log(stdout);
-          console.log("save to ",destKey);
-          S3.putObject({
-            Body: new Buffer(fs.readFileSync(resizedFile)),
-            Bucket: BUCKET,
-            ContentType: data.ContentType,
-            Key: destKey,
-            //ACL: 'public-read'
-          },(err,data)=>{
-              if(err)console.log("error",err);
-              console.log("success",data);
-          });
-          
+  console.log("opening", originalKey);
+  
+  //download the put file from S3 bucket
+  S3.getObject({ Bucket: BUCKET, Key: originalKey }).promise()
+
+    .then((data) => {
+      console.log("resize ...");
+      
+      //resize and save to tmp
+      im.resize({
+        srcData: data.Body,
+        dstPath: resizedFile,
+        width: width,
+        height: height,
+      }, function (err, stdout, stderr) {
+        if (err) cb(err);
+        
+        console.log("save to ", destKey);
+
+        //upload from tmp to S3
+        //Note: ACL is mandatory otherwise the page will display broken image due to access denied
+        //to set ACL, Lambda function context must have PutObjectACL permission
+        S3.putObject({
+          Body: new Buffer(fs.readFileSync(resizedFile)),
+          Bucket: BUCKET,
+          ContentType: data.ContentType,
+          Key: destKey,
+          ACL: 'public-read'  //<-- err 404 in page if missed
+        }, (err, data) => {
+          if (err) console.log("error", err);
+          console.log("success", data);
         });
+
+      });
     })
-    
-     .then(() =>{
-    //     fs.unlinkSync(resizedFile);
-         cb(null,"OK");
-     })
-    
+
+    .then(() => {
+      // It seems not necessary to dele file saved in tmp
+      //     fs.unlinkSync(resizedFile);
+      cb(null, "OK");
+    })
+
     .catch((err) => cb(err))
 }


### PR DESCRIPTION
This file contains the lambda function uploaded on aws 
In short, the function download an image from S3 bucket, resize it and upload it back to S3; source and destination folders are different.
The function is very simple but implements a core feature of the project

**check**
- We have to be sure that promises flow is correct otherwise the execution could end without checking for errors.
- Actually I've not idea about the resources used by this function, we should do an extimation considering how many images could be upload per hour
- I tried to remove files in tmp folder by `fs.unlinkSync(resizedFile)` but raise an error, let's check if we really need to delete them, after going in production we could realize we are using a lot of useless space in aws. 

***enanchement***
- We should remove any reference to specific project parameters to make this function reusable in other situations

***testing***
- Could be usefull to write a little wrapper for the `exports.handler` method to test locally the functions, testing on aws is usefull but slow down the code maintenance process, I have some ideas but before I would like to know yours.
- The function is simple but it's not a bad thing to write some tests 
- We Shoud implements some kind of alert in case of errors

***references and docs***
Based on [https://aws.amazon.com/it/blogs/compute/resize-images-on-the-fly-with-amazon-s3-aws-lambda-and-amazon-api-gateway/](url) (but using ImageMagic instead of Sharp) and the template downloaded from aws example named` image-processing-service`

Any suggestions is welcome ;)

